### PR TITLE
Plan and Participants

### DIFF
--- a/arrows-api-schema.yaml
+++ b/arrows-api-schema.yaml
@@ -35,6 +35,11 @@ components:
           readOnly: true
           format: uuid
           type: string
+        created_at:
+          readOnly: true
+          type: string
+          format: date-time
+          example: "2021-03-19T16:28:12Z"
         name:
           readOnly: true
           type: string

--- a/arrows-api-schema.yaml
+++ b/arrows-api-schema.yaml
@@ -70,11 +70,11 @@ components:
         - coordinator
         - template
       type: object
-    PlanMembership:
+    Participant:
       properties:
         object:
           readOnly: true
-          enum: ["plan_membership"]
+          enum: ["participant"]
           type: string
         id:
           readOnly: true
@@ -353,11 +353,20 @@ paths:
                 $ref: '#/components/schemas/Plan'
       tags:
         - Plans
-  /v1/plans/{plan_id}/memberships:
+  /v1/plans/{plan_id}/participants:
     post:
-      operationId: Create PlanMembership
+      description: "
+        Calling this endpoint is equivalent to inviting someone to a Plan in
+        the Arrows UI. Creating a participant via the API will not send them an
+        invite email, unlike adding someone via the UI.
+
+
+        This endpoint is also how you set a point person or coordinator on a
+        plan. Set these by passing in the appropriate `role` parameter.
+      "
+      operationId: Create Participant
       parameters:
-        - description: The UUID of the plan the membership is for.
+        - description: The UUID of the plan the participant is a part of.
           in: path
           name: plan_id
           required: true
@@ -367,15 +376,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PlanMembership'
+              $ref: '#/components/schemas/Participant'
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PlanMembership'
+                $ref: '#/components/schemas/Participant'
       tags:
-        - PlanMemberships
+        - Participants
   /v1/templates:
     get:
       operationId: List Templates
@@ -468,12 +477,9 @@ tags:
     The coordinator ID should be the ID of a team member that can be retrieved
     from the [Members](/v1/docs#tag/Members) endpoint.
   "
-- name: PlanMemberships
+- name: Participants
   description: "
-    PlanMemberships represent a user's participation in a plan. Calling this
-    endpoint is equivalent to inviting someone to a Plan in the Arrows UI.
-    Creating a membership via the API will not send them an invite email,
-    unlike adding someone via the UI.
+    Participants represent a user's participation in a plan. 
   "
 - name: Templates
   description: "

--- a/arrows-api-schema.yaml
+++ b/arrows-api-schema.yaml
@@ -76,6 +76,7 @@ components:
           format: uuid
           type: string
         plan:
+          readOnly: true
           format: uuid
           type: string
         user:
@@ -303,10 +304,16 @@ paths:
                 $ref: '#/components/schemas/Plan'
       tags:
         - Plans
-  /v1/plans/{id}/memberships:
+  /v1/plans/{plan_id}/memberships:
     post:
       operationId: Create PlanMembership
-      parameters: []
+      parameters:
+        - description: The UUID of the plan the membership is for.
+          in: path
+          name: plan_id
+          required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/arrows-api-schema.yaml
+++ b/arrows-api-schema.yaml
@@ -304,6 +304,49 @@ paths:
                 $ref: '#/components/schemas/Plan'
       tags:
         - Plans
+    get:
+      operationId: List Plans
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  object:
+                    enum: ["list"]
+                    type: string
+                  url: 
+                    enum: ["/v1/plans"]
+                    type: string
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Plan'
+      tags:
+      - Plans
+  /v1/plans/{id}:
+    get:
+      operationId: Retrieve Plan
+      parameters:
+        - description: The UUID identifying the plan.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plan'
+      tags:
+        - Plans
   /v1/plans/{plan_id}/memberships:
     post:
       operationId: Create PlanMembership

--- a/arrows-api-schema.yaml
+++ b/arrows-api-schema.yaml
@@ -155,8 +155,9 @@ components:
           type: string
         created_at:
           readOnly: true
+          type: string
           format: date-time
-          example: 1613765307
+          example: "2021-03-19T16:28:12Z"        
         type:
           enum: ["task.done", "phase.done"]
         data:

--- a/arrows-api-schema.yaml
+++ b/arrows-api-schema.yaml
@@ -79,7 +79,14 @@ components:
           format: uuid
           type: string
         user:
+          readOnly: true
           format: uuid
+          type: string
+        email:
+          writeOnly: true
+          type: string
+        name:
+          writeOnly: true
           type: string
         role:
           enum: 
@@ -88,17 +95,17 @@ components:
             - coordinator
           type: string
           default: participant
-        notifications:
+        notifications_tier:
           enum: 
             - ignoring
             - available
             - watching
             - everything
           type: string
-          default: available
+          default: watching
       required:
         - plan
-        - user
+        - email
     Template:
       properties:
         object:
@@ -407,8 +414,10 @@ tags:
   "
 - name: PlanMemberships
   description: "
-    PlanMemberships represent a user's participation in a plan. You'll need
-    two IDs to create a PlanMembership: a plan ID, and a user ID.
+    PlanMemberships represent a user's participation in a plan. Calling this
+    endpoint is equivalent to inviting someone to a Plan in the Arrows UI.
+    Creating a membership via the API will not send them an invite email,
+    unlike adding someone via the UI.
   "
 - name: Templates
   description: "

--- a/arrows-api-schema.yaml
+++ b/arrows-api-schema.yaml
@@ -317,11 +317,16 @@ paths:
         - Plans
     get:
       operationId: List Plans
-      parameters: []
-      requestBody:
-        content:
-          application/json:
-            schema:
+      parameters:
+        - name: archived
+          description: "
+            Filter for archived plans. By default returns only non-archived
+            plans.
+          "
+          in: query
+          schema:
+            type: string
+            example: "true"
       responses:
         '200':
           content:

--- a/arrows-api-schema.yaml
+++ b/arrows-api-schema.yaml
@@ -65,6 +65,40 @@ components:
         - coordinator
         - template
       type: object
+    PlanMembership:
+      properties:
+        object:
+          readOnly: true
+          enum: ["plan_membership"]
+          type: string
+        id:
+          readOnly: true
+          format: uuid
+          type: string
+        plan:
+          format: uuid
+          type: string
+        user:
+          format: uuid
+          type: string
+        role:
+          enum: 
+            - participant
+            - point_person
+            - coordinator
+          type: string
+          default: participant
+        notifications:
+          enum: 
+            - ignoring
+            - available
+            - watching
+            - everything
+          type: string
+          default: available
+      required:
+        - plan
+        - user
     Template:
       properties:
         object:
@@ -262,6 +296,23 @@ paths:
                 $ref: '#/components/schemas/Plan'
       tags:
         - Plans
+  /v1/plans/{id}/memberships:
+    post:
+      operationId: Create PlanMembership
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanMembership'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanMembership'
+      tags:
+        - PlanMemberships
   /v1/templates:
     get:
       operationId: List Templates
@@ -353,6 +404,11 @@ tags:
     three IDs to create a plan: a template ID, customer ID, and coordinator ID.
     The coordinator ID should be the ID of a team member that can be retrieved
     from the [Members](/v1/docs#tag/Members) endpoint.
+  "
+- name: PlanMemberships
+  description: "
+    PlanMemberships represent a user's participation in a plan. You'll need
+    two IDs to create a PlanMembership: a plan ID, and a user ID.
   "
 - name: Templates
   description: "

--- a/arrows-api-schema.yaml
+++ b/arrows-api-schema.yaml
@@ -107,6 +107,11 @@ components:
             - available
             - watching
             - everything
+          description: "
+            Will default to the notifications tier default for the role
+            assigned. The default role is 'participant', so the default
+            notifications_tier is the default for that role—'watching'.
+          "
           type: string
           default: watching
       required:


### PR DESCRIPTION
Update documentation to include:

- Participant object type
- GET `/v1/plans`
- GET `/v1/plans/{id}`
- POST `/v1/plans/{id}/participants`